### PR TITLE
Annotations for src/fig/bicoloured-cip.tex.

### DIFF
--- a/src/fig/bicoloured-cip.tex
+++ b/src/fig/bicoloured-cip.tex
@@ -21,3 +21,9 @@
 \Edge[style ={-},label={$a_{3}$},labelstyle={above}]({pt})({ptp1})
 \Edge[style ={-},label={$a_{4}$},labelstyle={above}]({ptp1})({ptp2})
 \Edge[style ={-},label={},labelstyle={above}]({ptp2})({p})
+
+\draw [thick, decorate,decoration={brace,amplitude=10pt},yshift=2pt] (0, 0.3) -- (7.9, 0.3) node [black,midway,yshift=16pt] {BIP};
+
+\draw [arrows = {-Stealth[length=10pt, inset=2pt]}] (8.5, 1.5) -- (8, 0.5);
+
+\node[text width = 1cm] at (9.2, 1.5) {cut};

--- a/wc.txt
+++ b/wc.txt
@@ -1,4 +1,4 @@
-      23      59    1218 src/fig/bicoloured-cip.tex
+      29      88    1473 src/fig/bicoloured-cip.tex
       24      84    1198 src/fig/cip-cut-left.tex
       24      94    1236 src/fig/cip-cut-right.tex
       34     127    1925 src/fig/cip-cut.tex
@@ -9,4 +9,4 @@
       18      48     927 src/fig/cip.tex
       18      54     946 src/fig/cipflip.tex
       22      97    1008 src/fig/vizing-fan.tex
-     203     647   10176 total
+     209     676   10431 total


### PR DESCRIPTION
Cut-and-pasted, almost verbatim, from src/fig/cip-cut.tex.